### PR TITLE
Change DTO usage strategy: service layer now receives and returns DTOs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,15 +27,21 @@ ext {
 	easyRandomCoreVersion = "5.0.0"
 	mockitoVersion = "5.2.0"
 	hibernateSpatialVersion = "6.1.7.Final"
+	mapstructVersion = "1.5.3.Final"
+	mapstructLombokBindingVersion = "0.2.0"
 }
 
 dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-graphql"
 	implementation "org.springframework.boot:spring-boot-starter-web"
 	implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+	implementation "org.springframework.boot:spring-boot-starter-validation"
 	implementation "org.postgresql:postgresql:${postgresqlDriverVersion}"
 	implementation "org.hibernate.orm:hibernate-spatial:${hibernateSpatialVersion}"
+	implementation "org.mapstruct:mapstruct:${mapstructVersion}"
 	compileOnly "org.projectlombok:lombok"
+	annotationProcessor "org.projectlombok:lombok-mapstruct-binding:${mapstructLombokBindingVersion}"
+	annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
 	annotationProcessor "org.projectlombok:lombok"
 	implementation "org.flywaydb:flyway-core:${flywayVersion}"
 	testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"

--- a/src/main/java/com/playground/demo/models/CreateStationRequest.java
+++ b/src/main/java/com/playground/demo/models/CreateStationRequest.java
@@ -1,0 +1,19 @@
+package com.playground.demo.models;
+
+import com.playground.demo.models.enums.Parish;
+import com.playground.demo.models.enums.StationStatus;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateStationRequest {
+    private double longitude;
+    private double latitude;
+    private String address;
+    private Parish parish;
+    private StationStatus status;
+    private int docks;
+}

--- a/src/main/java/com/playground/demo/models/NearStationsModel.java
+++ b/src/main/java/com/playground/demo/models/NearStationsModel.java
@@ -1,8 +1,16 @@
 package com.playground.demo.models;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
 import java.util.List;
 
-public record NearStationsModel(
-        List<StationModel> stations
-) {
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class NearStationsModel {
+    List<StationModel> stations;
 }

--- a/src/main/java/com/playground/demo/models/StationModel.java
+++ b/src/main/java/com/playground/demo/models/StationModel.java
@@ -3,18 +3,21 @@ package com.playground.demo.models;
 import com.playground.demo.models.enums.Parish;
 import com.playground.demo.models.enums.StationStatus;
 import lombok.*;
+import org.locationtech.jts.geom.Point;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
+@EqualsAndHashCode
 public class StationModel {
     private final int id;
-    private final String coordinates;
+    private final Point coordinates;
     private final String address;
     private final Parish parish;
     private final StationStatus status;
-    private final List<DockModel> docks;
+    private final List<DockModel> docks = new ArrayList<>();
 }

--- a/src/main/java/com/playground/demo/models/StationsSearchCriteria.java
+++ b/src/main/java/com/playground/demo/models/StationsSearchCriteria.java
@@ -1,0 +1,40 @@
+package com.playground.demo.models;
+
+import com.playground.demo.models.enums.StationStatus;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Point;
+
+import java.util.List;
+
+import static com.playground.demo.utils.GeometryUtils.GEOMETRY_FACTORY;
+import static java.util.Objects.nonNull;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StationsSearchCriteria {
+
+    @Nullable
+    private Double longitude;
+
+    @Nullable
+    private Double latitude;
+
+    @Nullable
+    private Integer radius;
+
+    @NotNull
+    @Builder.Default
+    private List<StationStatus> statuses = List.of(StationStatus.ACTIVE);
+
+    public Point getCoordinatesAsPoint() {
+        return nonNull(longitude) && nonNull(latitude) && nonNull(radius)
+                ? GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude))
+                : null;
+    }
+}

--- a/src/main/java/com/playground/demo/persistence/entities/enums/StationStatus.java
+++ b/src/main/java/com/playground/demo/persistence/entities/enums/StationStatus.java
@@ -5,5 +5,6 @@ public enum StationStatus {
     INSTALLING,
     TESTING,
     INACTIVE,
+    ON_MAINTENANCE,
     ACTIVE
 }

--- a/src/main/java/com/playground/demo/persistence/repositories/StationRepository.java
+++ b/src/main/java/com/playground/demo/persistence/repositories/StationRepository.java
@@ -1,6 +1,8 @@
 package com.playground.demo.persistence.repositories;
 
 import com.playground.demo.persistence.entities.StationEntity;
+import com.playground.demo.persistence.entities.enums.StationStatus;
+import jakarta.validation.constraints.NotNull;
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,6 +13,6 @@ import java.util.List;
 @Repository
 public interface StationRepository extends JpaRepository<StationEntity, Integer> {
 
-    @Query("SELECT s FROM StationEntity as s WHERE ST_DistanceSphere(s.coordinates, :currentLocation) < :radiusInMeters")
-    List<StationEntity> findAllInRadius(Point currentLocation, int radiusInMeters);
+    @Query("SELECT s FROM StationEntity as s WHERE (:currentLocation IS NULL OR ST_DistanceSphere(s.coordinates, :currentLocation) < :radiusInMeters) AND s.status IN :statuses")
+    List<StationEntity> findAllInRadius(Point currentLocation, Integer radiusInMeters, @NotNull List<StationStatus> statuses);
 }

--- a/src/main/java/com/playground/demo/services/StationService.java
+++ b/src/main/java/com/playground/demo/services/StationService.java
@@ -1,56 +1,72 @@
 package com.playground.demo.services;
 
 import com.playground.demo.exceptions.notfound.StationNotFoundException;
+import com.playground.demo.models.CreateStationRequest;
+import com.playground.demo.models.NearStationsModel;
+import com.playground.demo.models.StationModel;
+import com.playground.demo.models.StationsSearchCriteria;
 import com.playground.demo.persistence.entities.DockEntity;
 import com.playground.demo.persistence.entities.StationEntity;
 import com.playground.demo.persistence.entities.enums.AssetStatus;
 import com.playground.demo.persistence.repositories.StationRepository;
-import lombok.NonNull;
+import com.playground.demo.services.mappers.StationMapper;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
 public class StationService {
 
-    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
-
     private final StationRepository stationRepository;
 
-    @NonNull
-    public StationEntity getStation(int stationId) {
+    private final StationMapper stationMapper;
+
+    @NotNull
+    @Transactional(readOnly = true)
+    public StationModel getStation(int stationId) {
+        final var station = getStationAsEntity(stationId);
+
+        return stationMapper.mapToModel(station);
+    }
+
+    private StationEntity getStationAsEntity(int stationId) {
         return stationRepository.findById(stationId)
                 .orElseThrow(() -> new StationNotFoundException(stationId));
     }
 
-    @NonNull
-    public List<StationEntity> getAllStations() {
-        return stationRepository.findAll();
-    }
+    @NotNull
+    @Transactional(readOnly = true)
+    public NearStationsModel getAllStations(StationsSearchCriteria searchCriteria) {
+        final var statuses = stationMapper.mapStatusToEntity(searchCriteria.getStatuses());
+        final var stationsEntities = stationRepository.findAllInRadius(
+                searchCriteria.getCoordinatesAsPoint(),
+                searchCriteria.getRadius(),
+                statuses
+        );
 
-    @NonNull
-    public List<StationEntity> getAllStationsWithinRadius(double longitude, double latitude, int radiusInMeters) {
-        final var coordinatesAsPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude));
-        return stationRepository.findAllInRadius(coordinatesAsPoint, radiusInMeters);
+        final var stations = stationMapper.mapToModel(stationsEntities);
+
+        return new NearStationsModel(stations);
     }
 
     @Transactional
-    @NonNull
-    public StationEntity createStation(StationEntity stationToCreate, int docksToCreate) {
-        final var docks = IntStream.range(0, docksToCreate)
-                .mapToObj(number -> buildDock(stationToCreate, number))
+    @NotNull
+    public StationModel createStation(CreateStationRequest stationToCreate) {
+        final var stationEntity = stationMapper.mapToEntity(stationToCreate);
+
+        final var docks = IntStream.range(0, stationToCreate.getDocks())
+                .mapToObj(number -> buildDock(stationEntity, number))
                 .toList();
 
-        stationToCreate.setDocks(docks);
+        stationEntity.setDocks(docks);
 
-        return stationRepository.save(stationToCreate);
+        final var entity = stationRepository.save(stationEntity);
+
+        return stationMapper.mapToModel(entity);
     }
 
     private DockEntity buildDock(StationEntity station, int number) {
@@ -62,13 +78,17 @@ public class StationService {
     }
 
     @Transactional
-    @NonNull
-    public StationEntity updateStation(int stationId, StationEntity stationToUpdate) {
-        final var station = getStation(stationId);
+    @NotNull
+    public StationModel updateStation(int stationId, StationModel stationToUpdate) {
+        final var station = getStationAsEntity(stationId);
 
-        return station.setStatus(stationToUpdate.getStatus())
-                .setCoordinates(stationToUpdate.getCoordinates())
-                .setAddress(stationToUpdate.getAddress())
-                .setParish(stationToUpdate.getParish());
+        final var modelAsEntity = stationMapper.mapToEntity(stationToUpdate);
+
+        station.setStatus(modelAsEntity.getStatus())
+                .setCoordinates(modelAsEntity.getCoordinates())
+                .setAddress(modelAsEntity.getAddress())
+                .setParish(modelAsEntity.getParish());
+
+        return stationMapper.mapToModel(station);
     }
 }

--- a/src/main/java/com/playground/demo/services/mappers/StationMapper.java
+++ b/src/main/java/com/playground/demo/services/mappers/StationMapper.java
@@ -1,0 +1,28 @@
+package com.playground.demo.services.mappers;
+
+import com.playground.demo.models.CreateStationRequest;
+import com.playground.demo.models.StationModel;
+import com.playground.demo.models.enums.StationStatus;
+import com.playground.demo.persistence.entities.StationEntity;
+import com.playground.demo.utils.GeometryUtils;
+import org.locationtech.jts.geom.Coordinate;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(imports = {GeometryUtils.class, Coordinate.class})
+public interface StationMapper {
+
+    StationModel mapToModel(StationEntity entity);
+
+    List<StationModel> mapToModel(List<StationEntity> entity);
+
+    @Mapping(target = "coordinates", expression = "java(GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(createStationRequest.getLongitude(), createStationRequest.getLatitude())))")
+    @Mapping(target = "docks", ignore = true)
+    StationEntity mapToEntity(CreateStationRequest createStationRequest);
+
+    StationEntity mapToEntity(StationModel createStationRequest);
+
+    List<com.playground.demo.persistence.entities.enums.StationStatus> mapStatusToEntity(List<StationStatus> status);
+}

--- a/src/main/java/com/playground/demo/utils/GeometryUtils.java
+++ b/src/main/java/com/playground/demo/utils/GeometryUtils.java
@@ -1,0 +1,9 @@
+package com.playground.demo.utils;
+
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+
+public class GeometryUtils {
+    public static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+
+}

--- a/src/test/java/com/playground/demo/persistence/repositories/StationRepositoryTest.java
+++ b/src/test/java/com/playground/demo/persistence/repositories/StationRepositoryTest.java
@@ -6,8 +6,6 @@ import com.playground.demo.persistence.entities.enums.StationStatus;
 import com.playground.demo.utils.PostgisSQLContainerInitializer;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -15,6 +13,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.util.Arrays;
+
+import static com.playground.demo.utils.TestUtils.GEOMETRY_FACTORY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 
@@ -23,8 +24,6 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TES
 @ContextConfiguration(initializers = {PostgisSQLContainerInitializer.class})
 @ActiveProfiles("test")
 class StationRepositoryTest {
-
-    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
 
     @Autowired
     private StationRepository stationRepository;
@@ -37,7 +36,7 @@ class StationRepositoryTest {
         final var coordinates = GEOMETRY_FACTORY.createPoint(new Coordinate(38.77066006800165, -9.160284356927665));
 
         // when
-        final var stations = stationRepository.findAllInRadius(coordinates, 2000);
+        final var stations = stationRepository.findAllInRadius(coordinates, 2000, Arrays.asList(StationStatus.values()));
 
         // then
         assertThat(stations)
@@ -55,7 +54,7 @@ class StationRepositoryTest {
         final var coordinates = GEOMETRY_FACTORY.createPoint(new Coordinate(0, 0));
 
         // when
-        final var stations = stationRepository.findAllInRadius(coordinates, 2000);
+        final var stations = stationRepository.findAllInRadius(coordinates, 2000, Arrays.asList(StationStatus.values()));
 
         // then
         assertThat(stations)

--- a/src/test/java/com/playground/demo/services/StationServiceTest.java
+++ b/src/test/java/com/playground/demo/services/StationServiceTest.java
@@ -1,59 +1,89 @@
 package com.playground.demo.services;
 
 import com.playground.demo.exceptions.notfound.StationNotFoundException;
+import com.playground.demo.models.CreateStationRequest;
+import com.playground.demo.models.StationModel;
+import com.playground.demo.models.StationsSearchCriteria;
+import com.playground.demo.models.enums.Parish;
+import com.playground.demo.models.enums.StationStatus;
 import com.playground.demo.persistence.entities.StationEntity;
-import com.playground.demo.persistence.entities.enums.StationStatus;
 import com.playground.demo.persistence.repositories.StationRepository;
+import com.playground.demo.services.mappers.StationMapper;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.PrecisionModel;
-import org.mockito.InjectMocks;
+import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
+import static com.playground.demo.persistence.entities.enums.Parish.LUMIAR;
+import static com.playground.demo.persistence.entities.enums.StationStatus.ACTIVE;
+import static com.playground.demo.utils.TestUtils.GEOMETRY_FACTORY;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class StationServiceTest {
-    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+public class StationServiceTest {
     private final static EasyRandom OBJECT_GENERATOR;
-
 
     static {
         EasyRandomParameters parameters = new EasyRandomParameters()
+                .seed(1L)
                 .excludeField(field -> field.getName().equals("coordinates"))
+                .excludeField(field -> field.getName().equals("docks"))
                 .stringLengthRange(3, 10)
                 .collectionSizeRange(1, 15);
         OBJECT_GENERATOR = new EasyRandom(parameters);
     }
 
+    public StationMapper stationMapper = Mappers.getMapper(StationMapper.class);
     @Mock
     private StationRepository stationRepository;
 
-    @InjectMocks
     private StationService stationService;
+
+    @BeforeEach
+    void setUp() {
+        stationService = new StationService(stationRepository, stationMapper);
+    }
 
     @Test
     void givenAValidId_whenGettingAStation_thenStationIsReturned() {
         // given
-        final var expectedStation = OBJECT_GENERATOR.nextObject(StationEntity.class);
-        when(stationRepository.findById(expectedStation.getId())).thenReturn(Optional.of(expectedStation));
+        final var stationEntity = StationEntity.builder()
+                .id(OBJECT_GENERATOR.nextInt())
+                .coordinates(GEOMETRY_FACTORY.createPoint())
+                .address("ADDRESS")
+                .status(ACTIVE)
+                .parish(LUMIAR)
+                .build();
+        when(stationRepository.findById(stationEntity.getId())).thenReturn(Optional.of(stationEntity));
 
         // when
-        final var actualStation = stationService.getStation(expectedStation.getId());
+        final var actualStation = stationService.getStation(stationEntity.getId());
 
         // then
+        final var expectedStation = StationModel.builder()
+                .id(stationEntity.getId())
+                .coordinates(stationEntity.getCoordinates())
+                .address(stationEntity.getAddress())
+                .status(StationStatus.ACTIVE)
+                .parish(Parish.LUMIAR)
+                .build();
+
         assertThat(actualStation).isEqualTo(expectedStation);
     }
 
@@ -76,101 +106,159 @@ class StationServiceTest {
     @Test
     void givenThatStationsExists_whenGettingAllStations_thenListOfStationsIsReturned() {
         // given
-        final var expectedStations = OBJECT_GENERATOR.objects(StationEntity.class, 3).toList();
-        when(stationRepository.findAll()).thenReturn(expectedStations);
+        final var entities = OBJECT_GENERATOR.objects(StationEntity.class, 3).toList();
+        when(stationRepository.findAllInRadius(eq(null), eq(null), any())).thenReturn(entities);
+
+        final var searchCriteria = StationsSearchCriteria.builder()
+                .statuses(asList(StationStatus.values()))
+                .build();
 
         // when
-        final var actualStations = stationService.getAllStations();
+        final var actualStations = stationService.getAllStations(searchCriteria);
 
         // then
-        assertThat(actualStations).containsExactlyElementsOf(expectedStations);
+        assertThat(actualStations).isNotNull();
+        assertThat(actualStations.getStations()).isNotNull();
+
+        final var entitiesIds = entities.stream().map(StationEntity::getId).toList();
+        assertThat(actualStations.getStations())
+                .extracting(StationModel::getId)
+                .containsExactlyInAnyOrderElementsOf(entitiesIds);
     }
 
     @Test
     void givenThatNoStationExists_whenGettingAllStations_thenEmptyListIsReturned() {
         // given
-        when(stationRepository.findAll()).thenReturn(List.of());
+        when(stationRepository.findAllInRadius(any(), any(), any())).thenReturn(List.of());
 
         // when
-        final var actualStations = stationService.getAllStations();
+        final var actualStations = stationService.getAllStations(new StationsSearchCriteria());
 
         // then
-        assertThat(actualStations).isEmpty();
+        assertThat(actualStations).isNotNull();
+        assertThat(actualStations.getStations()).isEmpty();
     }
 
     @Test
     void givenThatStationsExists_whenGettingAllStationsWithinARadius_thenListOfStationsWithinRadiusIsReturned() {
         // given
-        final var expectedStations = OBJECT_GENERATOR.objects(StationEntity.class, 3).toList();
+        final var entities = OBJECT_GENERATOR.objects(StationEntity.class, 3).toList();
         final var coordinatesAsPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(38.77066006800165, -9.160284356927665));
-        when(stationRepository.findAllInRadius(coordinatesAsPoint, 50)).thenReturn(expectedStations);
+
+        final var searchCriteria = StationsSearchCriteria.builder()
+                .longitude(coordinatesAsPoint.getX())
+                .latitude(coordinatesAsPoint.getY())
+                .radius(50)
+                .statuses(Arrays.asList(StationStatus.values()))
+                .build();
+
+        when(stationRepository.findAllInRadius(
+                coordinatesAsPoint,
+                50,
+                Arrays.asList(com.playground.demo.persistence.entities.enums.StationStatus.values()))
+        ).thenReturn(entities);
 
         // when
-        final var actualStations = stationService.getAllStationsWithinRadius(
-                coordinatesAsPoint.getX(),
-                coordinatesAsPoint.getY(),
-                50
-        );
+        final var actualStations = stationService.getAllStations(searchCriteria);
 
         // then
-        assertThat(actualStations).containsExactlyElementsOf(expectedStations);
+        assertThat(actualStations).isNotNull();
+        assertThat(actualStations.getStations()).isNotNull();
+
+        final var entitiesIds = entities.stream().map(StationEntity::getId).toList();
+        assertThat(actualStations.getStations())
+                .extracting(StationModel::getId)
+                .containsExactlyInAnyOrderElementsOf(entitiesIds);
     }
 
     @Test
     void givenNoStationsWithinRadius_whenGettingAllStationsWithinARadius_thenListOfStationsIsEmpty() {
         // given
-        final var coordinatesAsPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(38.77066006800165, -9.160284356927665));
-        when(stationRepository.findAllInRadius(coordinatesAsPoint, 50)).thenReturn(List.of());
+        final var coordinatesAsPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(0, 0));
+        when(stationRepository.findAllInRadius(eq(coordinatesAsPoint), eq(50), any())).thenReturn(List.of());
+
+        final var searchCriteria = StationsSearchCriteria.builder()
+                .longitude(coordinatesAsPoint.getX())
+                .latitude(coordinatesAsPoint.getY())
+                .radius(50)
+                .statuses(Arrays.asList(StationStatus.values()))
+                .build();
 
         // when
-        final var actualStations = stationService.getAllStationsWithinRadius(
-                coordinatesAsPoint.getX(),
-                coordinatesAsPoint.getY(),
-                50
-        );
+        final var actualStations = stationService.getAllStations(searchCriteria);
 
         // then
-        assertThat(actualStations).isEmpty();
+        assertThat(actualStations).isNotNull();
+        assertThat(actualStations.getStations()).isEmpty();
     }
 
     @Test
     void givenValidArguments_whenCreatingAStation_thenCreatedStationIsReturned() {
         // given
-        final var expectedResult = OBJECT_GENERATOR.nextObject(StationEntity.class);
-        when(stationRepository.save(expectedResult)).thenReturn(expectedResult);
+        final var entity = StationEntity.builder()
+                .coordinates(GEOMETRY_FACTORY.createPoint(new Coordinate(0, 0)))
+                .address("ADDRESS")
+                .status(ACTIVE)
+                .parish(LUMIAR)
+                .docks(List.of())
+                .build();
+
+        doAnswer(answer -> entity.setId(OBJECT_GENERATOR.nextInt())).when(stationRepository).save(entity);
+
+        final var createRequest = CreateStationRequest.builder()
+                .address("ADDRESS")
+                .longitude(entity.getCoordinates().getX())
+                .longitude(entity.getCoordinates().getY())
+                .status(StationStatus.ACTIVE)
+                .parish(Parish.LUMIAR)
+                .build();
 
         // when
-        final var actualResult = stationService.createStation(expectedResult, 5);
+        final var createdStation = stationService.createStation(createRequest);
 
         // then
-        assertThat(actualResult).isEqualTo(expectedResult);
+        final var expectedStation = StationModel.builder()
+                .id(entity.getId())
+                .coordinates(entity.getCoordinates())
+                .address(entity.getAddress())
+                .status(StationStatus.ACTIVE)
+                .parish(Parish.LUMIAR)
+                .build();
+
+        assertThat(createdStation).isEqualTo(expectedStation);
     }
 
     @Test
     void givenValidArguments_whenUpdatingStation_thenUpdatedStationIsReturned() {
-        final var expectedResult = OBJECT_GENERATOR.nextObject(StationEntity.class);
-        final var objectBeforeUpdate = StationEntity.builder()
-                .id(expectedResult.getId())
-                .address(OBJECT_GENERATOR.nextObject(String.class))
-                .coordinates(expectedResult.getCoordinates())
-                .parish(expectedResult.getParish())
-                .status(OBJECT_GENERATOR.nextObject(StationStatus.class))
-                .docks(expectedResult.getDocks())
+        final var updatedModel = StationModel.builder()
+                .id(OBJECT_GENERATOR.nextInt())
+                .coordinates(GEOMETRY_FACTORY.createPoint(new Coordinate(0, 0)))
+                .address("ADDRESS")
+                .status(StationStatus.ACTIVE)
+                .parish(Parish.LUMIAR)
                 .build();
 
-        when(stationRepository.findById(expectedResult.getId())).thenReturn(Optional.of(objectBeforeUpdate));
+        final var objectBeforeUpdate = StationEntity.builder()
+                .id(updatedModel.getId())
+                .coordinates(updatedModel.getCoordinates())
+                .address(updatedModel.getAddress())
+                .status(ACTIVE)
+                .parish(LUMIAR)
+                .build();
+
+        when(stationRepository.findById(updatedModel.getId())).thenReturn(Optional.of(objectBeforeUpdate));
 
         // when
-        final var actualResult = stationService.updateStation(expectedResult.getId(), expectedResult);
+        final var actualResult = stationService.updateStation(updatedModel.getId(), updatedModel);
 
         // then
-        assertThat(actualResult).isEqualTo(expectedResult);
+        assertThat(actualResult).isEqualTo(updatedModel);
     }
 
     @Test
     void givenThatStationDoesNotExist_whenUpdatingStation_thenStationNotFoundIsThrown() {
         // given
-        final var randomStation = OBJECT_GENERATOR.nextObject(StationEntity.class);
+        final var randomStation = OBJECT_GENERATOR.nextObject(StationModel.class);
         when(stationRepository.findById(any())).thenReturn(Optional.empty());
 
         // when

--- a/src/test/java/com/playground/demo/utils/TestUtils.java
+++ b/src/test/java/com/playground/demo/utils/TestUtils.java
@@ -1,6 +1,8 @@
 package com.playground.demo.utils;
 
 import org.apache.commons.io.FileUtils;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
 
 import java.io.File;
 import java.io.IOException;
@@ -9,6 +11,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 
 public class TestUtils {
+    public static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
 
     public static <T> String readFileAsString(Class<T> testClass, String fileName) throws IOException {
 


### PR DESCRIPTION
## In this PR
- In order to have a better separation of concerns we now use shared DTOs between the controller and service layer.
- The service layer uses the introduced MapStruct mappers to map between entities (consumed by the persistence layer) and DTOs.
. The findAllStations and findAllStationsWithinRadius were merged to simplify the service (the latter remains).