### PR TITLE
Enable Create station

### DIFF
--- a/src/main/java/com/playground/demo/controllers/StationController.java
+++ b/src/main/java/com/playground/demo/controllers/StationController.java
@@ -1,13 +1,16 @@
 package com.playground.demo.controllers;
 
+import com.playground.demo.models.CreateStationRequest;
 import com.playground.demo.models.NearStationsModel;
 import com.playground.demo.models.StationModel;
 import com.playground.demo.models.StationsSearchCriteria;
 import com.playground.demo.services.StationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @RequestMapping("/stations")
@@ -30,9 +33,16 @@ public class StationController {
         return ResponseEntity.ok(station);
     }
 
-    @PostMapping
-    public ResponseEntity<String> createStation(StationModel station) {
-        return ResponseEntity.ok("{\"id\" : " + 1 + "}");
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<StationModel> createStation(@RequestBody final CreateStationRequest createRequest) {
+        final var createdStation = stationService.createStation(createRequest);
+
+        final var uri = UriComponentsBuilder
+                .fromPath("/stations/{id}")
+                .buildAndExpand(createdStation.getId())
+                .toUri();
+
+        return ResponseEntity.created(uri).body(createdStation);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/playground/demo/exceptions/StationControllerExceptionHandler.java
+++ b/src/main/java/com/playground/demo/exceptions/StationControllerExceptionHandler.java
@@ -1,17 +1,56 @@
 package com.playground.demo.exceptions;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.playground.demo.controllers.StationController;
 import com.playground.demo.exceptions.notfound.StationNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.util.stream.Collectors;
+
+@Slf4j
 @ControllerAdvice(assignableTypes = StationController.class)
 public class StationControllerExceptionHandler {
 
+    @ExceptionHandler
+    public ResponseEntity<ExceptionalResponse> handleNonCoveredExceptions(final Exception exception) {
+        log.error("A non-covered exception occurred", exception);
+
+        final var body = ExceptionalResponse.builder()
+                .reason("An unexpected exception occurred in the system, please contact an administrator if this persists.")
+                .build();
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ExceptionalResponse> handleMessageNotReadable(final HttpMessageNotReadableException messageNotReadableException) {
+        var cause = (JsonMappingException) messageNotReadableException.getCause();
+
+        var faultyField = cause.getPath().stream()
+                .map(path -> path.getFieldName() != null ? path.getFieldName() : "")
+                .collect(Collectors.joining("."));
+
+        final var message = cause.getCause() != null ? cause.getCause().getMessage() : cause.getMessage();
+
+        log.error("The received request is badly formed. Message = {}", message);
+
+        final var body = ExceptionalResponse.builder()
+                .reason("The request was badly formed! Please verify that the indicated field is using the accepted values.")
+                .faultyValue(faultyField, "Not valid")
+                .build();
+
+        return ResponseEntity.badRequest().body(body);
+    }
+
     @ExceptionHandler(StationNotFoundException.class)
     public ResponseEntity<ExceptionalResponse> handleStationNotFound(final StationNotFoundException notFoundException) {
+        log.error("Station with id {} could not be found", notFoundException.getStationId());
+
         final var body = ExceptionalResponse.builder()
                 .reason(notFoundException.getReason())
                 .faultyValue("id", notFoundException.getStationId())

--- a/src/test/resources/com/playground/demo/controllers/stationsController_createStation_invalidDuplicatedCoordinates.json
+++ b/src/test/resources/com/playground/demo/controllers/stationsController_createStation_invalidDuplicatedCoordinates.json
@@ -1,7 +1,0 @@
-{
-  "coordinates": "38.773492752219724, -9.161404255225367",
-  "address": "Estrada da Torre",
-  "parish": "LUMIAR",
-  "status": "INSTALLING",
-  "docks": 12
-}

--- a/src/test/resources/com/playground/demo/controllers/stationsController_createStation_invalidParish.json
+++ b/src/test/resources/com/playground/demo/controllers/stationsController_createStation_invalidParish.json
@@ -1,5 +1,6 @@
 {
-  "coordinates": "38.773492752219724, -9.161404255225367",
+  "longitude": 38.773492752219724,
+  "latitude": -9.161404255225367,
   "address": "Estrada da Torre",
   "parish": "NONEXISTENT_PARISH",
   "status": "INSTALLING",

--- a/src/test/resources/com/playground/demo/controllers/stationsController_createStation_invalidStatus.json
+++ b/src/test/resources/com/playground/demo/controllers/stationsController_createStation_invalidStatus.json
@@ -1,5 +1,6 @@
 {
-  "coordinates": "38.773492752219724, -9.161404255225367",
+  "longitude": 38.773492752219724,
+  "latitude": -9.161404255225367,
   "address": "Estrada da Torre",
   "parish": "LUMIAR",
   "status": "NOT_VALID_STATUS",

--- a/src/test/resources/com/playground/demo/controllers/stationsController_createStation_validRequest.json
+++ b/src/test/resources/com/playground/demo/controllers/stationsController_createStation_validRequest.json
@@ -3,5 +3,5 @@
   "address": "Estrada da Torre",
   "parish": "LUMIAR",
   "status": "INSTALLING",
-  "docks": 12
+  "docks": 2
 }


### PR DESCRIPTION
### Enable Create station
- Enable the creation of a single station. 
### Exception handling:
- Add treatment for non-covered exceptions by responding with a 500 and a generic message
- Add treatment for HttpMessageNotReadableException to handle bad requests on enumerators
- Add logs on all exception handling