### PR TITLE
Enable CRUD over BikeEntity

### DIFF
--- a/src/main/java/com/playground/demo/exceptions/notfound/BikeNotFoundException.java
+++ b/src/main/java/com/playground/demo/exceptions/notfound/BikeNotFoundException.java
@@ -1,0 +1,14 @@
+package com.playground.demo.exceptions.notfound;
+
+import com.playground.demo.exceptions.ApiException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BikeNotFoundException extends ApiException {
+
+    private final String reason = "The requested bike does not exist, please verify that the identifier is correct.";
+
+    private final int bikeId;
+}

--- a/src/main/java/com/playground/demo/models/BikeRequest.java
+++ b/src/main/java/com/playground/demo/models/BikeRequest.java
@@ -7,19 +7,16 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import static com.playground.demo.models.enums.AssetStatus.ACTIVE;
 
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class BikeModel {
-
-    private int id;
+public class BikeRequest {
     private BikeType type;
-    private AssetStatus status;
-    private int kms;
-    private LocalDate lastMaintenanceDate;
-    private double averageReview;
-}
+    @Builder.Default
+    private AssetStatus status = ACTIVE;
 
+    private int kms;
+}

--- a/src/main/java/com/playground/demo/models/StationRequest.java
+++ b/src/main/java/com/playground/demo/models/StationRequest.java
@@ -6,10 +6,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.*;
 
-@Getter
-@Setter
+@Data
 @Builder
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class StationRequest {

--- a/src/main/java/com/playground/demo/persistence/entities/BikeEntity.java
+++ b/src/main/java/com/playground/demo/persistence/entities/BikeEntity.java
@@ -31,7 +31,7 @@ public class BikeEntity {
     private AssetStatus status;
 
     @Column(nullable = false)
-    private int km;
+    private int kms;
 
     @Column(nullable = false)
     private LocalDate lastMaintenanceDate;

--- a/src/main/java/com/playground/demo/services/BikeService.java
+++ b/src/main/java/com/playground/demo/services/BikeService.java
@@ -1,0 +1,68 @@
+package com.playground.demo.services;
+
+import com.playground.demo.exceptions.notfound.BikeNotFoundException;
+import com.playground.demo.models.BikeModel;
+import com.playground.demo.models.BikeRequest;
+import com.playground.demo.persistence.entities.BikeEntity;
+import com.playground.demo.persistence.repositories.BikeRepository;
+import com.playground.demo.services.mappers.BikeMapper;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BikeService {
+
+    private final BikeRepository bikeRepository;
+
+    private final BikeMapper bikeMapper;
+
+    @NotNull
+    private BikeEntity getBikeAsEntity(final int bikeId) {
+        return bikeRepository.findById(bikeId)
+                .orElseThrow(() -> new BikeNotFoundException(bikeId));
+    }
+
+    @NotNull
+    @Transactional(readOnly = true)
+    public BikeModel getBike(final int bikeId) {
+        final var bike = getBikeAsEntity(bikeId);
+
+        return bikeMapper.mapToModel(bike);
+    }
+
+    @NotNull
+    @Transactional
+    public BikeModel createBike(@NotNull final BikeRequest bikeToCreate) {
+        log.info("Creating a new bike with the following parameters: {}", bikeToCreate);
+
+        final var bikeEntity = bikeMapper.mapToEntity(bikeToCreate);
+
+        final var entity = bikeRepository.save(bikeEntity);
+
+        log.info("Bike with identifier {} was creates", entity.getId());
+
+        return bikeMapper.mapToModel(entity);
+    }
+
+    @NotNull
+    @Transactional
+    public BikeModel updateBike(final int bikeId, @NotNull final BikeRequest bikeToUpdate) {
+        log.info("Updating bike {} with the following parameters: {}", bikeId, bikeToUpdate);
+
+        final var bike = getBikeAsEntity(bikeId);
+
+        final var entityWithRequestedChanges = bikeMapper.mapToEntity(bikeId, bikeToUpdate);
+
+        bike.setType(entityWithRequestedChanges.getType())
+                .setStatus(entityWithRequestedChanges.getStatus())
+                .setKms(entityWithRequestedChanges.getKms())
+                .setLastMaintenanceDate(entityWithRequestedChanges.getLastMaintenanceDate());
+
+        return bikeMapper.mapToModel(bike);
+    }
+}

--- a/src/main/java/com/playground/demo/services/StationService.java
+++ b/src/main/java/com/playground/demo/services/StationService.java
@@ -1,9 +1,9 @@
 package com.playground.demo.services;
 
 import com.playground.demo.exceptions.notfound.StationNotFoundException;
-import com.playground.demo.models.StationRequest;
 import com.playground.demo.models.NearStationsModel;
 import com.playground.demo.models.StationModel;
+import com.playground.demo.models.StationRequest;
 import com.playground.demo.models.StationsSearchCriteria;
 import com.playground.demo.persistence.entities.DockEntity;
 import com.playground.demo.persistence.entities.StationEntity;
@@ -42,7 +42,7 @@ public class StationService {
 
     @NotNull
     @Transactional(readOnly = true)
-    public NearStationsModel getAllStations(final StationsSearchCriteria searchCriteria) {
+    public NearStationsModel getAllStations(@NotNull final StationsSearchCriteria searchCriteria) {
         final var statuses = stationMapper.mapStatusToEntity(searchCriteria.getStatuses());
         final var stationsEntities = stationRepository.findAllInRadius(
                 searchCriteria.getCoordinatesAsPoint(),
@@ -57,7 +57,7 @@ public class StationService {
 
     @NotNull
     @Transactional
-    public StationModel createStation(final StationRequest stationToCreate) {
+    public StationModel createStation(@NotNull final StationRequest stationToCreate) {
         log.info("Creating a new station with the following parameters: {}", stationToCreate);
 
         final var stationEntity = stationMapper.mapToEntity(stationToCreate);
@@ -85,8 +85,8 @@ public class StationService {
 
     @NotNull
     @Transactional
-    public StationModel updateStation(final int stationId, final StationRequest stationToUpdate) {
-        log.info("Updating a new station with the following parameters: {}",stationToUpdate);
+    public StationModel updateStation(final int stationId, @NotNull final StationRequest stationToUpdate) {
+        log.info("Updating station {} with the following parameters: {}", stationId, stationToUpdate);
 
         final var station = getStationAsEntity(stationId);
 

--- a/src/main/java/com/playground/demo/services/mappers/BikeMapper.java
+++ b/src/main/java/com/playground/demo/services/mappers/BikeMapper.java
@@ -1,0 +1,28 @@
+package com.playground.demo.services.mappers;
+
+import com.playground.demo.models.BikeModel;
+import com.playground.demo.models.BikeRequest;
+import com.playground.demo.persistence.entities.BikeEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValueMappingStrategy;
+
+import java.time.LocalDate;
+
+@Mapper(imports = {LocalDate.class}, componentModel = "spring",
+        nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+public interface BikeMapper {
+
+    BikeModel mapToModel(final BikeEntity entity);
+
+    // todo:map average review once it is implemented
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "dock", ignore = true)
+    @Mapping(target = "kms", ignore = true)
+    @Mapping(target = "lastMaintenanceDate", expression = "java(LocalDate.now())")
+    BikeEntity mapToEntity(final BikeRequest bikeRequest);
+
+    @Mapping(target = "id", source = "bikeId")
+    @Mapping(target = "dock", ignore = true)
+    BikeEntity mapToEntity(final int bikeId, final BikeRequest bikeRequest);
+}

--- a/src/main/resources/db/migration/V200323__create_schema.sql
+++ b/src/main/resources/db/migration/V200323__create_schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS bikes
     id                    serial PRIMARY KEY,
     type                  varchar(50) NOT NULL, -- ELECTRIC / CLASSIC
     status                varchar(50) NOT NULL, -- ACTIVE / INACTIVE / ON_MAINTENANCE / REQUIRING_MAINTENANCE
-    km                    int         NOT NULL DEFAULT 0,
+    kms                   int         NOT NULL DEFAULT 0,
     last_maintenance_date date        NULL
 );
 

--- a/src/test/java/com/playground/demo/persistence/repositories/BikeRepositoryTest.java
+++ b/src/test/java/com/playground/demo/persistence/repositories/BikeRepositoryTest.java
@@ -30,14 +30,14 @@ class BikeRepositoryTest {
             .id(111)
             .type(BikeType.ELECTRIC)
             .status(AssetStatus.ACTIVE)
-            .km(555)
+            .kms(555)
             .lastMaintenanceDate(LocalDate.of(2022, 3, 15))
             .build();
     private static final BikeEntity BIKE_2 = BikeEntity.builder()
             .id(222)
             .type(BikeType.ELECTRIC)
             .status(AssetStatus.ACTIVE)
-            .km(777)
+            .kms(777)
             .lastMaintenanceDate(LocalDate.of(2022, 3, 14))
             .build();
 
@@ -45,7 +45,7 @@ class BikeRepositoryTest {
             .id(333)
             .type(BikeType.CLASSIC)
             .status(AssetStatus.REQUIRING_MAINTENANCE)
-            .km(1234)
+            .kms(1234)
             .lastMaintenanceDate(LocalDate.of(2021, 3, 15))
             .build();
 

--- a/src/test/java/com/playground/demo/services/BikeServiceTest.java
+++ b/src/test/java/com/playground/demo/services/BikeServiceTest.java
@@ -1,0 +1,162 @@
+package com.playground.demo.services;
+
+import com.playground.demo.exceptions.notfound.BikeNotFoundException;
+import com.playground.demo.models.BikeModel;
+import com.playground.demo.models.BikeRequest;
+import com.playground.demo.persistence.entities.BikeEntity;
+import com.playground.demo.persistence.entities.DockEntity;
+import com.playground.demo.persistence.entities.enums.AssetStatus;
+import com.playground.demo.persistence.entities.enums.BikeType;
+import com.playground.demo.persistence.repositories.BikeRepository;
+import com.playground.demo.services.mappers.BikeMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.Random;
+
+import static com.playground.demo.models.enums.AssetStatus.ACTIVE;
+import static com.playground.demo.models.enums.AssetStatus.INACTIVE;
+import static com.playground.demo.models.enums.BikeType.ELECTRIC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BikeServiceTest {
+
+    // Reoccurring data
+    private static final BikeEntity BIKE_ENTITY = BikeEntity.builder()
+            .id(1)
+            .type(BikeType.ELECTRIC)
+            .status(AssetStatus.ACTIVE)
+            .kms(111)
+            .dock(DockEntity.builder().build())
+            .build();
+
+    private static final BikeModel BIKE_MODEL = BikeModel.builder()
+            .id(BIKE_ENTITY.getId())
+            .type(ELECTRIC)
+            .status(ACTIVE)
+            .kms(BIKE_ENTITY.getKms())
+            .averageReview(0d)
+            .build();
+
+    private final BikeMapper bikeMapper = Mappers.getMapper(BikeMapper.class);
+
+    @Mock
+    private BikeRepository bikeRepository;
+
+    private BikeService bikeService;
+
+    @BeforeEach
+    void setUp() {
+        bikeService = new BikeService(bikeRepository, bikeMapper);
+    }
+
+    @Test
+    void givenAValidId_whenGettingABike_thenBikeIsReturned() {
+        // given
+        when(bikeRepository.findById(BIKE_ENTITY.getId())).thenReturn(Optional.of(BIKE_ENTITY));
+
+        // when
+        final var actualBike = bikeService.getBike(BIKE_ENTITY.getId());
+
+        // then
+        assertThat(actualBike).isEqualTo(BIKE_MODEL);
+    }
+
+    @Test
+    void givenAnInvalidId_whenGettingABike_thenBikeNotFoundIsThrown() {
+        // given
+        when(bikeRepository.findById(any())).thenReturn(Optional.empty());
+
+        // when
+        final var exception = assertThrowsExactly(
+                BikeNotFoundException.class,
+                () -> bikeService.getBike(BIKE_ENTITY.getId())
+        );
+
+        // then
+        assertThat(exception.getReason())
+                .isEqualTo("The requested bike does not exist, please verify that the identifier is correct.");
+    }
+
+    @Test
+    void givenValidArguments_whenCreatingABike_thenCreatedBikeIsReturned() {
+        // given
+        final var saveInput = BikeEntity.builder()
+                .type(BikeType.ELECTRIC)
+                .status(AssetStatus.ACTIVE)
+                .lastMaintenanceDate(LocalDate.now())
+                .build();
+
+        final var createRequest = BikeRequest.builder()
+                .type(ELECTRIC)
+                .status(ACTIVE)
+                .build();
+
+        doAnswer(answer -> saveInput.setId(new Random().nextInt())).when(bikeRepository).save(saveInput);
+
+        // when
+        final var createdBike = bikeService.createBike(createRequest);
+
+        // then
+        final var expectedBike = BikeModel.builder()
+                .id(saveInput.getId())
+                .type(ELECTRIC)
+                .status(ACTIVE)
+                .lastMaintenanceDate(saveInput.getLastMaintenanceDate())
+                .build();
+
+        assertThat(createdBike).isEqualTo(expectedBike);
+    }
+
+    @Test
+    void givenValidArguments_whenUpdatingABike_thenUpdatedBikeIsReturned() {
+        // given
+        final var updateRequest = BikeRequest.builder()
+                .type(ELECTRIC)
+                .status(INACTIVE)
+                .kms(1234)
+                .build();
+        when(bikeRepository.findById(BIKE_ENTITY.getId())).thenReturn(Optional.of(BIKE_ENTITY));
+
+        // when
+        final var updatedBike = bikeService.updateBike(BIKE_ENTITY.getId(), updateRequest);
+
+        // then
+        final var expectedBike = BikeModel.builder()
+                .id(BIKE_ENTITY.getId())
+                .type(ELECTRIC)
+                .status(INACTIVE)
+                .kms(1234)
+                .lastMaintenanceDate(BIKE_ENTITY.getLastMaintenanceDate())
+                .build();
+
+        assertThat(updatedBike).isEqualTo(expectedBike);
+    }
+
+    @Test
+    void givenThatBikeDoesNotExist_whenUpdatingStation_thenBikeNotFoundIsThrown() {
+        // given
+        when(bikeRepository.findById(1)).thenReturn(Optional.empty());
+
+        // then
+        final var exception = assertThrowsExactly(
+                BikeNotFoundException.class,
+                () -> bikeService.updateBike(1, BikeRequest.builder().build())
+        );
+
+        // then
+        assertThat(exception.getReason())
+                .isEqualTo("The requested bike does not exist, please verify that the identifier is correct.");
+    }
+}

--- a/src/test/java/com/playground/demo/services/StationServiceTest.java
+++ b/src/test/java/com/playground/demo/services/StationServiceTest.java
@@ -37,7 +37,7 @@ public class StationServiceTest {
     private final static EasyRandom OBJECT_GENERATOR;
 
     static {
-        EasyRandomParameters parameters = new EasyRandomParameters()
+        final var parameters = new EasyRandomParameters()
                 .seed(1L)
                 .excludeField(field -> field.getName().equals("coordinates"))
                 .stringLengthRange(3, 10)
@@ -45,7 +45,7 @@ public class StationServiceTest {
         OBJECT_GENERATOR = new EasyRandom(parameters);
     }
 
-    public StationMapper stationMapper = Mappers.getMapper(StationMapper.class);
+    private final StationMapper stationMapper = Mappers.getMapper(StationMapper.class);
     @Mock
     private StationRepository stationRepository;
 

--- a/src/test/resources/db/init.sql
+++ b/src/test/resources/db/init.sql
@@ -2,7 +2,7 @@ INSERT INTO stations (id, coordinates, address, parish, status)
 VALUES (1, ST_GeomFromText('POINT(38.77066006800165 -9.160284356927665)', 4326), 'Rua Luís de Freitas Branco', 'LUMIAR', 'ACTIVE'),
        (2, ST_GeomFromText('POINT(38.772483954508274 -9.154035912185192)', 4326), 'Rua Nóbrega e Sousa', 'LUMIAR', 'PLANNED');
 
-INSERT INTO bikes (id, type, status, km, last_maintenance_date)
+INSERT INTO bikes (id, type, status, kms, last_maintenance_date)
 VALUES (111, 'ELECTRIC', 'ACTIVE', 555, '03/15/2022'),
        (222, 'ELECTRIC', 'ACTIVE', 777, '03/14/2022'),
        (333, 'CLASSIC', 'REQUIRING_MAINTENANCE', 1234, '03/15/2021');


### PR DESCRIPTION
- Create a service to act as a proxy for the CRUD operations - delete is not supported
- Update Bike table property km to kms

General improvements:
- Added `@NotNull`annotation to all service layer