### PR TITLE
GET & POST bikes

### DIFF
--- a/src/main/java/com/playground/demo/controllers/BikeController.java
+++ b/src/main/java/com/playground/demo/controllers/BikeController.java
@@ -1,0 +1,38 @@
+package com.playground.demo.controllers;
+
+import com.playground.demo.models.BikeModel;
+import com.playground.demo.models.BikeRequest;
+import com.playground.demo.services.BikeService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RestController
+@RequestMapping("/bikes")
+@RequiredArgsConstructor
+public class BikeController {
+
+    private final BikeService bikeService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BikeModel> getSingleBike(@PathVariable final int id) {
+        final var bike = bikeService.getBike(id);
+
+        return ResponseEntity.ok(bike);
+    }
+
+    @PostMapping
+    public ResponseEntity<BikeModel> createBike(@RequestBody @NotNull @Valid final BikeRequest createRequest) {
+        final var createdBike = bikeService.createBike(createRequest);
+
+        final var uri = UriComponentsBuilder
+                .fromPath("/bikes/{id}")
+                .buildAndExpand(createdBike.getId())
+                .toUri();
+
+        return ResponseEntity.created(uri).body(createdBike);
+    }
+}

--- a/src/main/java/com/playground/demo/exceptions/handlers/ControllersExceptionHandler.java
+++ b/src/main/java/com/playground/demo/exceptions/handlers/ControllersExceptionHandler.java
@@ -1,7 +1,8 @@
-package com.playground.demo.exceptions;
+package com.playground.demo.exceptions.handlers;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.playground.demo.controllers.StationController;
+import com.playground.demo.exceptions.ExceptionalResponse;
+import com.playground.demo.exceptions.notfound.BikeNotFoundException;
 import com.playground.demo.exceptions.notfound.StationNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -15,8 +16,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import java.util.stream.Collectors;
 
 @Slf4j
-@ControllerAdvice(assignableTypes = StationController.class)
-public class StationControllerExceptionHandler {
+@ControllerAdvice(basePackages = "com.playground.demo.controllers")
+public class ControllersExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<ExceptionalResponse> handleNonCoveredExceptions(final Exception exception) {
@@ -79,6 +80,18 @@ public class StationControllerExceptionHandler {
         final var body = ExceptionalResponse.builder()
                 .reason(notFoundException.getReason())
                 .faultyValue("id", notFoundException.getStationId())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(BikeNotFoundException.class)
+    public ResponseEntity<ExceptionalResponse> handleStationNotFound(final BikeNotFoundException notFoundException) {
+        log.error("Bike with id {} could not be found", notFoundException.getBikeId());
+
+        final var body = ExceptionalResponse.builder()
+                .reason(notFoundException.getReason())
+                .faultyValue("id", notFoundException.getBikeId())
                 .build();
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);

--- a/src/main/java/com/playground/demo/models/BikeRequest.java
+++ b/src/main/java/com/playground/demo/models/BikeRequest.java
@@ -2,6 +2,7 @@ package com.playground.demo.models;
 
 import com.playground.demo.models.enums.AssetStatus;
 import com.playground.demo.models.enums.BikeType;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,5 +19,6 @@ public class BikeRequest {
     @Builder.Default
     private AssetStatus status = ACTIVE;
 
+    @PositiveOrZero
     private int kms;
 }

--- a/src/main/java/com/playground/demo/persistence/entities/BikeEntity.java
+++ b/src/main/java/com/playground/demo/persistence/entities/BikeEntity.java
@@ -19,7 +19,7 @@ import java.time.LocalDate;
 public class BikeEntity {
     @Id
     @Column(nullable = false)
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     @Column(nullable = false)

--- a/src/main/java/com/playground/demo/services/BikeService.java
+++ b/src/main/java/com/playground/demo/services/BikeService.java
@@ -12,6 +12,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
+import static com.playground.demo.persistence.entities.enums.AssetStatus.ACTIVE;
+import static com.playground.demo.persistence.entities.enums.AssetStatus.REQUIRING_MAINTENANCE;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -58,10 +63,14 @@ public class BikeService {
 
         final var entityWithRequestedChanges = bikeMapper.mapToEntity(bikeId, bikeToUpdate);
 
+        // Maintenance has finished, updating last maintenance date
+        if (bike.getStatus() == REQUIRING_MAINTENANCE && entityWithRequestedChanges.getStatus() == ACTIVE) {
+            bike.setLastMaintenanceDate(LocalDate.now());
+        }
+
         bike.setType(entityWithRequestedChanges.getType())
                 .setStatus(entityWithRequestedChanges.getStatus())
-                .setKms(entityWithRequestedChanges.getKms())
-                .setLastMaintenanceDate(entityWithRequestedChanges.getLastMaintenanceDate());
+                .setKms(entityWithRequestedChanges.getKms());
 
         return bikeMapper.mapToModel(bike);
     }

--- a/src/main/java/com/playground/demo/services/mappers/BikeMapper.java
+++ b/src/main/java/com/playground/demo/services/mappers/BikeMapper.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
         nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
 public interface BikeMapper {
 
+    // TODO: Map average review once entity is created
     BikeModel mapToModel(final BikeEntity entity);
 
     // todo:map average review once it is implemented
@@ -24,5 +25,6 @@ public interface BikeMapper {
 
     @Mapping(target = "id", source = "bikeId")
     @Mapping(target = "dock", ignore = true)
+    @Mapping(target = "lastMaintenanceDate", ignore = true)
     BikeEntity mapToEntity(final int bikeId, final BikeRequest bikeRequest);
 }

--- a/src/test/java/com/playground/demo/controllers/BikeControllerIntegrationTest.java
+++ b/src/test/java/com/playground/demo/controllers/BikeControllerIntegrationTest.java
@@ -1,0 +1,161 @@
+package com.playground.demo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.playground.demo.exceptions.ExceptionalResponse;
+import com.playground.demo.models.BikeModel;
+import com.playground.demo.models.BikeRequest;
+import com.playground.demo.models.enums.AssetStatus;
+import com.playground.demo.models.enums.BikeType;
+import com.playground.demo.utils.PostgisSQLContainerInitializer;
+import com.playground.demo.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+
+@Testcontainers
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(initializers = {PostgisSQLContainerInitializer.class})
+@ActiveProfiles("test")
+class BikeControllerIntegrationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = "/db/init.sql")
+    @Sql(executionPhase = AFTER_TEST_METHOD, scripts = "/db/clean.sql")
+    @Test
+    void givenABikeId_whenGettingABike_thenBikeIsReturned() {
+        // when
+        final var response = restTemplate.getForEntity("/bikes/111", BikeModel.class);
+
+        // then
+        assertThat(response).isNotNull();
+
+        final var expectedResponse = BikeModel.builder()
+                .id(111)
+                .type(BikeType.ELECTRIC)
+                .status(AssetStatus.ACTIVE)
+                .kms(555)
+                .lastMaintenanceDate(LocalDate.of(2022, 3, 15))
+                .build();
+
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(response.getBody()).isEqualTo(expectedResponse);
+    }
+
+    @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = "/db/init.sql")
+    @Sql(executionPhase = AFTER_TEST_METHOD, scripts = "/db/clean.sql")
+    @Test
+    void givenABikeId_whenGettingABikeThatDoesNotExist_thenNotFoundIsReturned() {
+        // when
+        final var response = restTemplate.getForEntity("/bikes/987654", BikeModel.class);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
+    }
+
+    @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = "/db/init.sql")
+    @Sql(executionPhase = AFTER_TEST_METHOD, scripts = "/db/clean.sql")
+    @Test
+    void givenValidArguments_whenCreatingABike_thenBikeIsPersisted() {
+        // given
+        final var bikeRequest = BikeRequest.builder()
+                .type(BikeType.ELECTRIC)
+                .status(AssetStatus.INACTIVE)
+                .kms(123456798) // should be ignored as all bikes start with 0
+                .build();
+
+        final var headers = new HttpHeaders();
+        headers.setContentType(APPLICATION_JSON);
+
+        final var entity = new HttpEntity<>(bikeRequest, headers);
+
+        // when
+        final var response = restTemplate.postForEntity("/bikes", entity, BikeModel.class);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(CREATED);
+
+        final var createdBike = response.getBody();
+
+        assertThat(createdBike).isNotNull();
+        assertThat(createdBike.getId()).isNotZero();
+        assertThat(createdBike.getKms()).isZero();
+
+        assertThat(response.getHeaders().getLocation())
+                .isNotNull()
+                .isEqualTo(UriComponentsBuilder.fromPath("/bikes/{id}").buildAndExpand(createdBike.getId()).toUri());
+
+        // Verify it was persisted
+        final var getBikeResponse = restTemplate.getForEntity("/bikes/" + createdBike.getId(), BikeModel.class);
+
+        assertThat(getBikeResponse.getStatusCode()).isEqualTo(OK);
+        assertThat(getBikeResponse.getBody()).isEqualTo(createdBike);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "bikeController/bikeRequest_invalidStatus.json",
+            "bikeController/bikeRequest_invalidType.json",
+            "bikeController/bikeRequest_invalidKms.json"
+    })
+    void givenInvalidArguments_whenCreatingABike_thenBadRequestIsReturned(final String filename) throws IOException {
+        // given
+        final var input = TestUtils.readFileAsString(this.getClass(), filename);
+
+        final var headers = new HttpHeaders();
+        headers.setContentType(APPLICATION_JSON);
+
+        final var entity = new HttpEntity<>(input, headers);
+
+        // when
+        final var response = restTemplate.postForEntity("/bikes", entity, ExceptionalResponse.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(BAD_REQUEST);
+        assertThat(response.getBody())
+                .isNotNull()
+                .extracting(ExceptionalResponse::getReason)
+                .isEqualTo("The request was badly formed! Please verify that the indicated field is using the accepted values.");
+    }
+
+    @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = "/db/init.sql")
+    @Sql(executionPhase = AFTER_TEST_METHOD, scripts = "/db/clean.sql")
+    @Test
+    void givenValidArguments_whenUpdatingABike_thenUpdatedBikeIsPersisted() {
+
+    }
+
+    @Sql(executionPhase = BEFORE_TEST_METHOD, scripts = "/db/init.sql")
+    @Sql(executionPhase = AFTER_TEST_METHOD, scripts = "/db/clean.sql")
+    @Test
+    void givenInvalidArguments_whenUpdatingABike_thenBadRequestIsReturned() {
+
+    }
+}

--- a/src/test/java/com/playground/demo/services/BikeServiceTest.java
+++ b/src/test/java/com/playground/demo/services/BikeServiceTest.java
@@ -145,6 +145,41 @@ class BikeServiceTest {
     }
 
     @Test
+    void givenValidArguments_whenUpdatingABikeFromRequiringMaintenanceToActive_thenBikeWithUpdatedLastMaintenanceDateIsReturned() {
+        // given
+        final var updateRequest = BikeRequest.builder()
+                .type(ELECTRIC)
+                .status(ACTIVE)
+                .kms(1234)
+                .build();
+
+        final var bikeRequiringMaintenance = BikeEntity.builder()
+                .id(1)
+                .type(BikeType.ELECTRIC)
+                .status(AssetStatus.REQUIRING_MAINTENANCE)
+                .kms(111)
+                .lastMaintenanceDate(LocalDate.of(2020, 5, 1))
+                .dock(DockEntity.builder().build())
+                .build();
+
+        when(bikeRepository.findById(BIKE_ENTITY.getId())).thenReturn(Optional.of(bikeRequiringMaintenance));
+
+        // when
+        final var updatedBike = bikeService.updateBike(BIKE_ENTITY.getId(), updateRequest);
+
+        // then
+        final var expectedBike = BikeModel.builder()
+                .id(BIKE_ENTITY.getId())
+                .type(ELECTRIC)
+                .status(ACTIVE)
+                .kms(1234)
+                .lastMaintenanceDate(LocalDate.now()) // This can make test fail if the execution start in one day and assertion is made in the following day!
+                .build();
+
+        assertThat(updatedBike).isEqualTo(expectedBike);
+    }
+
+    @Test
     void givenThatBikeDoesNotExist_whenUpdatingStation_thenBikeNotFoundIsThrown() {
         // given
         when(bikeRepository.findById(1)).thenReturn(Optional.empty());

--- a/src/test/resources/com/playground/demo/controllers/bikeController/bikeRequest_invalidKms.json
+++ b/src/test/resources/com/playground/demo/controllers/bikeController/bikeRequest_invalidKms.json
@@ -1,0 +1,5 @@
+{
+  "status": "ACTIVE",
+  "type": "ELECTRIC",
+  "kms": -1
+}

--- a/src/test/resources/com/playground/demo/controllers/bikeController/bikeRequest_invalidStatus.json
+++ b/src/test/resources/com/playground/demo/controllers/bikeController/bikeRequest_invalidStatus.json
@@ -1,0 +1,5 @@
+{
+  "status": "NOT_VALID_STATUS",
+  "type": "ELECTRIC",
+  "kms": 123
+}

--- a/src/test/resources/com/playground/demo/controllers/bikeController/bikeRequest_invalidType.json
+++ b/src/test/resources/com/playground/demo/controllers/bikeController/bikeRequest_invalidType.json
@@ -1,0 +1,5 @@
+{
+  "status": "ACTIVE",
+  "type": "NOT_VALID_TYPE",
+  "kms": 123
+}


### PR DESCRIPTION
## In this PR
### Business logic refactoring:
- When a bike is updated from "Requiring Maintenance" to "Active", then it is assumed that the maintenance has taken place and the "lastMaintenanceData" is updated automatically - it is not API caller job to do this anymore.
- Added the validation for the kms, they can only be positive or zero.

### API endpoints:
- Implemented the GET bike and POST bike endpoints to enable attainment and creation of a single bike
- Integration tests were provided.